### PR TITLE
Upgrade Refiner SDK version to 1.4.0

### DIFF
--- a/example/androidApp/build.gradle.kts
+++ b/example/androidApp/build.gradle.kts
@@ -49,5 +49,5 @@ dependencies {
     implementation(AndroidX.constraintLayout)
     implementation(AndroidX.core.ktx)
     implementation(AndroidX.activity.ktx)
-    implementation("io.refiner:refiner:1.3.12")
+    implementation("io.refiner:refiner:1.4.0")
 }


### PR DESCRIPTION
# What it does
This pull request upgrades Refiner SDK to 1.4.0