### PR TITLE
Upgrade Refiner SDK version to 1.5.3

### DIFF
--- a/example/androidApp/build.gradle.kts
+++ b/example/androidApp/build.gradle.kts
@@ -49,5 +49,5 @@ dependencies {
     implementation(AndroidX.constraintLayout)
     implementation(AndroidX.core.ktx)
     implementation(AndroidX.activity.ktx)
-    implementation("io.refiner:refiner:1.5.2")
+    implementation("io.refiner:refiner:1.5.3")
 }


### PR DESCRIPTION
# What it does
This pull request upgrades Refiner SDK to 1.5.3