### PR TITLE
Add GitHub Actions CI/CD workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+# What it does
+
+This pull request ...
+
+# How to test it
+
+1.
+
+# Acceptance criteria
+
+*
+
+# Link to ticket
+
+[trello url]

--- a/.github/workflows/update-example.yml
+++ b/.github/workflows/update-example.yml
@@ -1,65 +1,39 @@
-name: Update Example App
-
-# Triggered by mobile-sdk-internal after Android SDK is published to Maven Central.
-# Updates the SDK version reference in the example app and commits directly to main.
+name: Update SDK Version
 
 on:
   repository_dispatch:
-    types: [release]
-  # Manual re-trigger in case the repository_dispatch fails
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Android SDK version (e.g. 1.7.0)"
-        required: true
+    types: [android-sdk-release]
 
 jobs:
   update:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
-      - name: Resolve version
-        id: resolve
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SDK_RELEASE_PAT }}
+
+      - name: Extract version
+        id: version
+        run: echo "VERSION=${{ github.event.client_payload.version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Update example app SDK version
         run: |
-          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            echo "version=${{ github.event.client_payload.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
-          fi
+          sed -i 's/implementation("io.refiner:refiner:[^"]*")/implementation("io.refiner:refiner:${{ steps.version.outputs.VERSION }}")/' example/androidApp/build.gradle.kts
 
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Checkout main
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Configure git
+      - name: Commit, tag, and push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Release ${{ steps.version.outputs.VERSION }}"
+          git tag "${{ steps.version.outputs.VERSION }}"
+          git push origin main --tags
 
-      - name: Bump SDK version in example app
-        run: |
-          VERSION="${{ steps.resolve.outputs.version }}"
-          sed -i "s/\"io\.refiner:refiner:[0-9.]*\"/\"io.refiner:refiner:${VERSION}\"/" \
-            example/androidApp/build.gradle.kts
-          grep "io.refiner:refiner" example/androidApp/build.gradle.kts
-
-      - name: Commit and push to main
-        run: |
-          VERSION="${{ steps.resolve.outputs.version }}"
-          git add example/androidApp/build.gradle.kts
-          if git diff --staged --quiet; then
-            echo "No changes detected — version may already be up to date."
-          else
-            git commit -m "Update SDK to ${VERSION}"
-            git push origin main
-          fi
-          echo "## Updated example app to Android SDK ${VERSION}" >> $GITHUB_STEP_SUMMARY
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.VERSION }}
+          name: ${{ steps.version.outputs.VERSION }}
+          generate_release_notes: true

--- a/.github/workflows/update-example.yml
+++ b/.github/workflows/update-example.yml
@@ -1,0 +1,65 @@
+name: Update Example App
+
+# Triggered by mobile-sdk-internal after Android SDK is published to Maven Central.
+# Updates the SDK version reference in the example app and commits directly to main.
+
+on:
+  repository_dispatch:
+    types: [release]
+  # Manual re-trigger in case the repository_dispatch fails
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Android SDK version (e.g. 1.7.0)"
+        required: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve version
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            echo "version=${{ github.event.client_payload.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump SDK version in example app
+        run: |
+          VERSION="${{ steps.resolve.outputs.version }}"
+          sed -i "s/\"io\.refiner:refiner:[0-9.]*\"/\"io.refiner:refiner:${VERSION}\"/" \
+            example/androidApp/build.gradle.kts
+          grep "io.refiner:refiner" example/androidApp/build.gradle.kts
+
+      - name: Commit and push to main
+        run: |
+          VERSION="${{ steps.resolve.outputs.version }}"
+          git add example/androidApp/build.gradle.kts
+          if git diff --staged --quiet; then
+            echo "No changes detected — version may already be up to date."
+          else
+            git commit -m "Update SDK to ${VERSION}"
+            git push origin main
+          fi
+          echo "## Updated example app to Android SDK ${VERSION}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
# What it does

Adds a GitHub Actions workflow to automate the example app SDK version update when a new Android SDK is published.

**Workflow:**

- `update-example.yml` — Triggered via `repository_dispatch` (`android-sdk-release` event) from `mobile-sdk-internal` after the Android SDK is published to Maven Central; bumps `io.refiner:refiner:x.x.x` in `example/androidApp/build.gradle.kts`, commits, tags, pushes to main, and creates a GitHub Release.

**Required setup:**
- Add `SDK_RELEASE_PAT` secret (Fine-grained PAT with Contents R/W)

# How to test it

1. After merging and setting up the PAT secret, trigger a test release from `mobile-sdk-internal` by pushing an `android-x.x.x` tag
2. Verify the `build.gradle.kts` dependency is updated, committed, tagged, and a GitHub Release is created

# Acceptance criteria

- `update-example.yml` workflow file is valid YAML
- Workflow responds to `repository_dispatch` with type `android-sdk-release`
- The `sed` command correctly updates the version in `example/androidApp/build.gradle.kts`
- Git tag and GitHub Release are created automatically

# Link to ticket

https://trello.com/c/BL2fe7u7/158-setup-ci-cd-pipeline